### PR TITLE
Complete Tutorial 9 - POST endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,22 @@ inner class $CLASS_NAME$ {
 * `@Nested` annotation and `inner class` are used to group tests.
 * Add live template for nested test. See [Live Template](#live-template) section.
 * Refactor `/api/bank` url to `baseUrl` constant in `BankControllerTest`
+
+## Tutorial 9 - Post endpoint
+
+### What's new?
+
+- [x] Add POST endpoint to `BankController`.
+- [x] Add test for POST endpoint to `BankControllerTest`.
+- [x] Add `ObjectMapper` bean to `BankControllerTest` to convert `Bank` object to JSON string.
+- [x] Add `IllegalArgumentException` handler to `BankController` to handle request with existing account number.
+
+### What's in the tutorial
+
+* Refactor `mockMvc` member variable to `@Autowired` primary constructor in `BankControllerTest`.
+* Refactor assert object contents statements in `BankControllerTest` to use `ObjectMapper`.
+* Change mock banks list to `mutableListOf` to add new bank.
+    * (Kotlin basic) In Kotlin, `listOf` is immutable list, so it can't be changed.
+    * `mutableListOf` is mutable list, so it can be changed directly.
+    * If you want to use immutable list on this case, you should return new list with added or removed item.
+      > From [Effective Kotlin](http://www.yes24.com/Product/Goods/106225986)

--- a/src/main/kotlin/com/artieyoe/tutorials/springboot/thenewboston/controller/BankConroller.kt
+++ b/src/main/kotlin/com/artieyoe/tutorials/springboot/thenewboston/controller/BankConroller.kt
@@ -14,6 +14,11 @@ class BankController(private var service: BankService) {
     fun handleNotFound(e: NoSuchElementException): ResponseEntity<String> =
         ResponseEntity(e.message, HttpStatus.NOT_FOUND)
 
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun handleBadRequest(e: IllegalArgumentException): ResponseEntity<String> =
+        ResponseEntity(e.message, HttpStatus.BAD_REQUEST)
+
+
     @GetMapping
     fun getBanks(): Collection<Bank> {
         return service.getBanks()
@@ -24,4 +29,9 @@ class BankController(private var service: BankService) {
         return service.getBank(accountNumber)
     }
 
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun addBank(@RequestBody bank: Bank): Bank {
+        return service.addBank(bank)
+    }
 }

--- a/src/main/kotlin/com/artieyoe/tutorials/springboot/thenewboston/datasource/BankDataSource.kt
+++ b/src/main/kotlin/com/artieyoe/tutorials/springboot/thenewboston/datasource/BankDataSource.kt
@@ -5,4 +5,6 @@ import com.artieyoe.tutorials.springboot.thenewboston.model.Bank
 interface BankDataSource {
     fun retrieveBanks(): Collection<Bank>
     fun retrieveBank(accountNumber: String): Bank
+    fun createBank(bank: Bank): Bank
+
 }

--- a/src/main/kotlin/com/artieyoe/tutorials/springboot/thenewboston/datasource/mock/MockBankDataSource.kt
+++ b/src/main/kotlin/com/artieyoe/tutorials/springboot/thenewboston/datasource/mock/MockBankDataSource.kt
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Repository
 
 @Repository
 class MockBankDataSource : BankDataSource {
-    val banks = listOf(
+    val banks = mutableListOf(
         Bank("1234", 3.14, 17),
         Bank("1010", 17.0, 0),
         Bank("5678", 0.0, 100)
@@ -19,4 +19,14 @@ class MockBankDataSource : BankDataSource {
             ?: throw NoSuchElementException("Could not find a bank with account number $accountNumber")
 
     }
+
+    override fun createBank(bank: Bank): Bank {
+        if (banks.any { it.accountNumber == bank.accountNumber }) {
+            throw IllegalArgumentException("Bank with account number ${bank.accountNumber} already exists")
+        }
+        banks.add(bank)
+
+        return bank
+    }
+
 }

--- a/src/main/kotlin/com/artieyoe/tutorials/springboot/thenewboston/service/BankService.kt
+++ b/src/main/kotlin/com/artieyoe/tutorials/springboot/thenewboston/service/BankService.kt
@@ -13,4 +13,8 @@ class BankService(private val dataSource: BankDataSource) {
     fun getBank(accountNumber: String): Bank {
         return dataSource.retrieveBank(accountNumber)
     }
+
+    fun addBank(bank: Bank): Bank {
+        return dataSource.createBank(bank)
+    }
 }


### PR DESCRIPTION
### What's new?

- [x] Add POST endpoint to `BankController`.
- [x] Add test for POST endpoint to `BankControllerTest`.
- [x] Add `ObjectMapper` bean to `BankControllerTest` to convert `Bank` object to JSON string.
- [x] Add `IllegalArgumentException` handler to `BankController` to handle request with existing account number.

### What's in the tutorial

* Refactor `mockMvc` member variable to `@Autowired` primary constructor in `BankControllerTest`.
* Refactor assert object contents statements in `BankControllerTest` to use `ObjectMapper`.
* Change mock banks list to `mutableListOf` to add new bank.
    * (Kotlin basic) In Kotlin, `listOf` is immutable list, so it can't be changed.
    * `mutableListOf` is mutable list, so it can be changed directly.
    * If you want to use immutable list on this case, you should return new list with added or removed item.
      > From [Effective Kotlin](http://www.yes24.com/Product/Goods/106225986)