### PR TITLE
Complete Tutorial 10 - Patch endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,16 @@ inner class $CLASS_NAME$ {
     * `mutableListOf` is mutable list, so it can be changed directly.
     * If you want to use immutable list on this case, you should return new list with added or removed item.
       > From [Effective Kotlin](http://www.yes24.com/Product/Goods/106225986)
+
+## Tutorial 10 - Patch endpoint
+
+### What's new?
+
+- [x] Add Patch endpoint to `BankController`.
+- [x] Add test for Patch endpoint to `BankControllerTest`.
+
+### What's in the tutorial
+
+* Nothing special. Just add patch endpoint and test.
+* Refactor assert object contents statements in `BankControllerTest` to use `ObjectMapper` was in this tutorial. not in
+  the tutorial 9.

--- a/src/main/kotlin/com/artieyoe/tutorials/springboot/thenewboston/controller/BankConroller.kt
+++ b/src/main/kotlin/com/artieyoe/tutorials/springboot/thenewboston/controller/BankConroller.kt
@@ -34,4 +34,9 @@ class BankController(private var service: BankService) {
     fun addBank(@RequestBody bank: Bank): Bank {
         return service.addBank(bank)
     }
+
+    @PatchMapping
+    fun updateBank(@RequestBody bank: Bank): Bank {
+        return service.updateBank(bank)
+    }
 }

--- a/src/main/kotlin/com/artieyoe/tutorials/springboot/thenewboston/datasource/BankDataSource.kt
+++ b/src/main/kotlin/com/artieyoe/tutorials/springboot/thenewboston/datasource/BankDataSource.kt
@@ -6,5 +6,6 @@ interface BankDataSource {
     fun retrieveBanks(): Collection<Bank>
     fun retrieveBank(accountNumber: String): Bank
     fun createBank(bank: Bank): Bank
+    fun updateBank(bank: Bank): Bank
 
 }

--- a/src/main/kotlin/com/artieyoe/tutorials/springboot/thenewboston/datasource/mock/MockBankDataSource.kt
+++ b/src/main/kotlin/com/artieyoe/tutorials/springboot/thenewboston/datasource/mock/MockBankDataSource.kt
@@ -29,4 +29,13 @@ class MockBankDataSource : BankDataSource {
         return bank
     }
 
+    override fun updateBank(bank: Bank): Bank {
+        val currentBank = banks.firstOrNull() { it.accountNumber == bank.accountNumber }
+            ?: throw NoSuchElementException("Could not find a bank with account number ${bank.accountNumber}")
+
+        banks.remove(currentBank)
+        banks.add(bank)
+
+        return bank
+    }
 }

--- a/src/main/kotlin/com/artieyoe/tutorials/springboot/thenewboston/service/BankService.kt
+++ b/src/main/kotlin/com/artieyoe/tutorials/springboot/thenewboston/service/BankService.kt
@@ -17,4 +17,8 @@ class BankService(private val dataSource: BankDataSource) {
     fun addBank(bank: Bank): Bank {
         return dataSource.createBank(bank)
     }
+
+    fun updateBank(bank: Bank): Bank {
+        return dataSource.updateBank(bank)
+    }
 }

--- a/src/test/kotlin/com/artieyoe/tutorials/springboot/thenewboston/controller/BankControllerTest.kt
+++ b/src/test/kotlin/com/artieyoe/tutorials/springboot/thenewboston/controller/BankControllerTest.kt
@@ -12,6 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.patch
 import org.springframework.test.web.servlet.post
 
 @SpringBootTest
@@ -134,10 +135,61 @@ internal class BankControllerTest @Autowired constructor(
                 .andExpect {
                     status { isBadRequest() }
                 }
-
         }
-
-
     }
 
+    @Nested
+    @DisplayName("PATCH /api/banks/{accountNumber}")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class PatchExistingBank {
+        @Test
+        fun `should update an existing bank`() {
+            // given
+            val updatedBank = Bank("1234", 1.0, 1)
+
+            // when
+            val performPatchRequest = mockMvc.patch(baseUrl) {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(updatedBank)
+            }
+
+            // then
+            performPatchRequest.andDo { print() }
+                .andExpect {
+                    status { isOk() }
+                    content {
+                        contentType(MediaType.APPLICATION_JSON)
+                        json(objectMapper.writeValueAsString(updatedBank))
+                    }
+                }
+
+            mockMvc.get("$baseUrl/${updatedBank.accountNumber}")
+                .andExpect {
+                    content {
+                        json(objectMapper.writeValueAsString(updatedBank))
+                    }
+                }
+        }
+
+        @Test
+        fun `should return BAD REQUEST if no bank with given account number exists`() {
+            // given
+            val invalidBank = Bank("does_not_exist", 1.0, 1)
+
+            // when
+            val performPatchRequest = mockMvc.patch(baseUrl) {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(invalidBank)
+            }
+
+            // then
+            performPatchRequest
+                .andDo { print() }
+                .andExpect {
+                    status { isNotFound() }
+                }
+
+
+        }
+    }
 }


### PR DESCRIPTION
### What's new?

- [x] Add Patch endpoint to `BankController`.
- [x] Add test for Patch endpoint to `BankControllerTest`.

### What's in the tutorial

* Nothing special. Just add patch endpoint and test.
* Refactor assert object contents statements in `BankControllerTest` to use `ObjectMapper` was in this tutorial. not in
  the tutorial 9.